### PR TITLE
Refactor astro.config.mjs to add external dependency 'query-string' to vite build options

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -10,4 +10,11 @@ export default defineConfig({
   output: "server",
   integrations: [tailwind()],
   adapter: vercel(),
+  vite: {
+    build: {
+      rollupOptions: {
+        external: ['query-string']
+      }
+    }
+  }
 });


### PR DESCRIPTION
This pull request refactors the astro.config.mjs file to include the external dependency 'query-string' in the vite build options. This change ensures that the 'query-string' module is properly included in the build process.